### PR TITLE
fix: robust z3 import detection

### DIFF
--- a/src/pages/Model.tsx
+++ b/src/pages/Model.tsx
@@ -21,6 +21,13 @@ function getErrorMessage(e: unknown): string {
     return e instanceof Error ? e.message : String(e);
 }
 
+// Regex to detect any form of z3 import at the start of a line while
+// ignoring commented lines (e.g. "# import z3"). It matches:
+//  - "import z3"
+//  - "import z3.something"
+//  - "from z3 import ..."
+const z3ImportRegex = /^\s*(?:import\s+z3(?:\.\w+)?|from\s+z3\s+import\b)/m;
+
 export default function Model() {
     const [status, setStatus] = useState<Status>("idle");
     const [log, setLog] = useState<string>("");
@@ -74,7 +81,7 @@ f"Hello from Python!\\nPython {platform.python_version()}\\nSys: {sys.version.sp
             const src = await srcResp.text();
 
             // Detect z3 import
-            if (/\bimport\s+z3\b|from\s+z3\s+import\b/.test(src)) {
+            if (z3ImportRegex.test(src)) {
                 setLog(
                     `Loaded trinity_formal_model.py (${src.length} bytes).
 


### PR DESCRIPTION
## Summary
- anchor z3 import detection to line starts and skip commented lines
- support import z3, import z3.* and from z3 import ...

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `node -e "const fs=require('fs');const regex=/^\s*(?:import\s+z3(?:\.\w+)?|from\s+z3\s+import\b)/m;const variants={orig:'public/trinity_formal_model.py',noz3:'public/variant_no_z3.py',import:'public/variant_import_z3.py',importsub:'public/variant_import_z3_solver.py',from:'public/variant_from_z3.py',comment:'public/variant_comment_z3.py'};for(const [name,path] of Object.entries(variants)){const src=fs.readFileSync(path,'utf8');console.log(name,regex.test(src));}"`

------
https://chatgpt.com/codex/tasks/task_e_6899e33b39988322a48b04ea9b24f432