### PR TITLE
Ensure pyodide script loads once before initialization

### DIFF
--- a/src/lib/pyodide.ts
+++ b/src/lib/pyodide.ts
@@ -5,6 +5,7 @@ export interface Pyodide {
     runPythonAsync(code: string): Promise<unknown>;
 }
 
+let pyodideScript: Promise<void> | null = null;
 let pyodideReady: Promise<Pyodide> | null = null;
 
 declare global {
@@ -18,9 +19,8 @@ export async function getPyodide(): Promise<Pyodide> {
 
     const url = "https://cdn.jsdelivr.net/pyodide/v0.26.1/full/pyodide.js";
 
-    // Load Pyodide script only once
-    if (!document.querySelector(`script[src="${url}"]`)) {
-        await new Promise<void>((resolve, reject) => {
+    if (!pyodideScript) {
+        pyodideScript = new Promise<void>((resolve, reject) => {
             const s = document.createElement("script");
             s.src = url;
             s.async = true;
@@ -29,6 +29,8 @@ export async function getPyodide(): Promise<Pyodide> {
             document.head.appendChild(s);
         });
     }
+
+    await pyodideScript;
 
     if (!window.loadPyodide) {
         throw new Error("Pyodide loader not found after script load.");


### PR DESCRIPTION
## Summary
- track Pyodide script loading with `pyodideScript` promise
- await script loading before invoking `loadPyodide`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899e3371a508322a39f723755c5f962