### PR TITLE
fix: encode code fallback in CodeViewer

### DIFF
--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -31,11 +31,12 @@ export default function CodeViewer({ src, language = "python", title }: Props) {
         };
     }, [src]);
 
-    const highlighted = useMemo(() => {
+    const highlighted = useMemo<string>(() => {
         try {
             return Prism.highlight(code, Prism.languages[language], language);
         } catch {
-            return code; // fallback: raw
+            // Fallback: encode raw text to avoid HTML injection
+            return Prism.util.encode(code) as string;
         }
     }, [code, language]);
 


### PR DESCRIPTION
## Summary
- encode raw code if Prism highlighting fails to avoid HTML injection
- ensure highlighted output always returns safe HTML

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899e339a4588322bee4dd1641370e2e